### PR TITLE
sigctx: move to lazy-load initialization of signal listener

### DIFF
--- a/sigctx/sigctx.go
+++ b/sigctx/sigctx.go
@@ -4,29 +4,34 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 )
 
-var ctx context.Context
-
-func init() {
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithCancel(context.Background())
-
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-
-	go func() {
-		select {
-		case <-ch:
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
-}
+var (
+	ctx  context.Context
+	once sync.Once
+)
 
 // New signal-bound context.  Context terminates when either SIGINT or SIGTERM
 // is caught.
 func New() context.Context {
+	once.Do(func() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithCancel(context.Background())
+
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+
+		go func() {
+			select {
+			case <-ch:
+				cancel()
+			case <-ctx.Done():
+			}
+			signal.Stop(ch)
+		}()
+	})
+
 	return ctx
 }


### PR DESCRIPTION
sigctx: move to lazy-load initialization of signal listener using sync.Once in the New() method.  This change prevents a situation where a program that imports this library but doesn't use (code calling sigctx.New() isn't invoked) no longer exits in response to SIGINT.